### PR TITLE
refactor: extract ErrorBoundary component and add docs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,42 +1,11 @@
 import { BrowserRouter } from 'react-router-dom';
 import AppRoutes from './routes/AppRoutes';
 import Chatbot from './components/common/Chatbot';
+import ErrorBoundary from './components/common/ErrorBoundary';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import React from 'react';
 import './styles/app.css';
-
-// ErrorBoundary to catch component errors
-class ErrorBoundary extends React.Component {
-  state = { hasError: false, error: null };
-  
-  static getDerivedStateFromError(error) {
-    return { hasError: true, error };
-  }
-  
-  componentDidCatch(error, errorInfo) {
-    console.log("Error in component:", errorInfo.componentStack);
-  }
-  
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="p-4 text-center">
-          <h2 className="text-xl font-bold text-red-600">Component Error</h2>
-          <p className="text-gray-700">{this.state.error.message}</p>
-          <pre className="text-xs text-left">{this.state.error.stack}</pre>
-          <button 
-            className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
-            onClick={() => this.setState({ hasError: false })}
-          >
-            Try Again
-          </button>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
 
 function App() {
   return (

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,10 @@
+# Source Overview
+
+This directory contains the client-side code for the application.
+
+- **components/common** – shared utilities such as `ErrorBoundary` and `Chatbot`.
+- **components/layout** – layout building blocks like `Header`, `Hero`, and `Footer`.
+- **pages** – route-level pages rendered by `AppRoutes`.
+- **routes** – route definitions for page components.
+
+`App.jsx` wires everything together, wrapping routes in `ErrorBoundary` to catch rendering errors.

--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  state = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.log('Error in component:', errorInfo.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-center">
+          <h2 className="text-xl font-bold text-red-600">Component Error</h2>
+          <p className="text-gray-700">{this.state.error.message}</p>
+          <pre className="text-xs text-left">{this.state.error.stack}</pre>
+          <button
+            className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
+            onClick={() => this.setState({ hasError: false })}
+          >
+            Try Again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- move ErrorBoundary logic into reusable component
- document source directory structure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars errors)*
- `npx eslint src/App.jsx src/components/common/ErrorBoundary.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a847ec40f4833382a77e1f63ed229b