### PR TITLE
feat: add backend booking retrieval

### DIFF
--- a/backend/Bookings/middleware/bookingMiddleware.js
+++ b/backend/Bookings/middleware/bookingMiddleware.js
@@ -37,3 +37,25 @@ export async function saveBooking(req, res, next) {
     res.status(500).json({ message: 'Failed to save booking' });
   }
 }
+
+export async function getBookings(req, res) {
+  try {
+    let bookings = [];
+    try {
+      const data = await fs.readFile(DATA_PATH, 'utf-8');
+      bookings = JSON.parse(data);
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+
+    const { userId } = req.query;
+    const filtered = userId
+      ? bookings.filter((b) => String(b.userId) === String(userId))
+      : bookings;
+
+    res.json(filtered);
+  } catch (err) {
+    console.error('Booking fetch error:', err);
+    res.status(500).json({ message: 'Failed to load bookings' });
+  }
+}

--- a/backend/Bookings/routes/bookingRoute.js
+++ b/backend/Bookings/routes/bookingRoute.js
@@ -1,7 +1,9 @@
 import express from 'express';
-import { validateBooking, saveBooking } from '../middleware/bookingMiddleware.js';
+import { validateBooking, saveBooking, getBookings } from '../middleware/bookingMiddleware.js';
 
 const router = express.Router();
+
+router.get('/', getBookings);
 
 router.post('/', validateBooking, saveBooking, (req, res) => {
   res.status(201).json({ message: 'Booking created', booking: req.booking });

--- a/src/pages/Booking/MyBookings.jsx
+++ b/src/pages/Booking/MyBookings.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useUser } from '@clerk/clerk-react';
 import '../../styles/components/MyBookings.css';
 import { globalAdventureData } from '../../data/mock/data';
 import Header from '../../components/layout/Header';
@@ -6,11 +7,22 @@ import Footer from '../../components/layout/Footer';
 
 export default function MyBookings() {
   const [bookings, setBookings] = useState([]);
+  const { user } = useUser();
 
   useEffect(() => {
-    const stored = JSON.parse(localStorage.getItem('myBookings') || '[]');
-    setBookings(stored);
-  }, []);
+    async function fetchBookings() {
+      try {
+        const res = await fetch(`http://localhost:5000/api/bookings?userId=${user?.id}`);
+        if (!res.ok) throw new Error('Failed to load bookings');
+        const data = await res.json();
+        setBookings(data);
+      } catch (err) {
+        console.error(err);
+        setBookings([]);
+      }
+    }
+    if (user) fetchBookings();
+  }, [user]);
 
   if (!bookings.length) {
     return (


### PR DESCRIPTION
## Summary
- add `getBookings` middleware to read saved bookings and support user filtering
- expose GET `/api/bookings` route
- load bookings from backend in `MyBookings` page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: 48 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a840eeab94833380978ab205a61371